### PR TITLE
Reflect removed files to Makefile.sources

### DIFF
--- a/mesalib/src/mesa/Makefile.sources
+++ b/mesalib/src/mesa/Makefile.sources
@@ -277,8 +277,6 @@ MATH_FILES = \
 	math/m_matrix.c \
 	math/m_matrix.h \
 	math/m_trans_tmp.h \
-	math/m_translate.c \
-	math/m_translate.h \
 	math/m_vector.c \
 	math/m_vector.h
 
@@ -339,12 +337,8 @@ STATETRACKER_FILES = \
 	state_tracker/st_cb_bitmap.c \
 	state_tracker/st_cb_bitmap.h \
 	state_tracker/st_cb_bitmap_shader.c \
-	state_tracker/st_cb_blit.c \
-	state_tracker/st_cb_blit.h \
 	state_tracker/st_cb_clear.c \
 	state_tracker/st_cb_clear.h \
-	state_tracker/st_cb_condrender.c \
-	state_tracker/st_cb_condrender.h \
 	state_tracker/st_cb_copyimage.c \
 	state_tracker/st_cb_copyimage.h \
 	state_tracker/st_cb_drawpixels.c \
@@ -354,36 +348,16 @@ STATETRACKER_FILES = \
 	state_tracker/st_cb_drawtex.h \
 	state_tracker/st_cb_eglimage.c \
 	state_tracker/st_cb_eglimage.h \
-	state_tracker/st_cb_fbo.c \
-	state_tracker/st_cb_fbo.h \
 	state_tracker/st_cb_feedback.c \
 	state_tracker/st_cb_feedback.h \
 	state_tracker/st_cb_flush.c \
 	state_tracker/st_cb_flush.h \
-	state_tracker/st_cb_memoryobjects.c \
-	state_tracker/st_cb_memoryobjects.h \
-	state_tracker/st_cb_perfmon.c \
-	state_tracker/st_cb_perfmon.h \
-	state_tracker/st_cb_perfquery.c \
-	state_tracker/st_cb_perfquery.h \
-	state_tracker/st_cb_program.c \
-	state_tracker/st_cb_program.h \
-	state_tracker/st_cb_queryobj.c \
-	state_tracker/st_cb_queryobj.h \
 	state_tracker/st_cb_rasterpos.c \
 	state_tracker/st_cb_rasterpos.h \
 	state_tracker/st_cb_readpixels.c \
 	state_tracker/st_cb_readpixels.h \
-	state_tracker/st_cb_semaphoreobjects.c \
-	state_tracker/st_cb_semaphoreobjects.h \
-	state_tracker/st_cb_syncobj.c \
-	state_tracker/st_cb_syncobj.h \
 	state_tracker/st_cb_texture.c \
 	state_tracker/st_cb_texture.h \
-	state_tracker/st_cb_viewport.c \
-	state_tracker/st_cb_viewport.h \
-	state_tracker/st_cb_xformfb.c \
-	state_tracker/st_cb_xformfb.h \
 	state_tracker/st_context.c \
 	state_tracker/st_context.h \
 	state_tracker/st_copytex.c \


### PR DESCRIPTION
mesalib in the tree is updated, however the removed files are still listed in Makefile.sources.
Fix build errors.